### PR TITLE
Update paths.js

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -191,7 +191,7 @@ export const getAndroidUpdateFilesContentOptions = ({
     {
       files: 'android/settings.gradle',
       from: [/rootProject.name = "(.*)"/g, /rootProject.name = '(.*)'/g],
-      to: `rootProject.name = '${newName}'`,
+      to: `rootProject.name = "${newName}"`,
     },
     {
       files: [`android/app/src/main/java/${newBundleIDAsPath}/MainActivity.java`],


### PR DESCRIPTION
To allow rootProject.name value's string with special character (e.g ' )without escaping it (ie /'). (ie. instead of wrapping rootProject.name string value in single quote 'city\'superE-Shop', with this double quoted string value for rootProject.name, "city'superE-Shop" can be write without escaping it using backward slash)